### PR TITLE
add ghr deployment in order to upload artifacts to GitHub release page.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,3 +29,10 @@ test:
   post:
     - make arm5 arm6 arm7 linux_386 linux_amd64 raspi raspi2 armadillo edison:
         pwd: ../.go_workspace/src/${REPO_PATH}
+
+deployment:
+  production:
+    branch: master
+    commands:
+      - go get github.com/tcnksm/ghr
+      - ghr -u shiguredo -r fuji --replace --prerelease pre-release /home/ubuntu/.go_workspace/src/github.com/shiguredo/fuji/downloads


### PR DESCRIPTION
Add ghr (https://github.com/tcnksm/ghr) to upload artifacts to GitHub Release page. 

This is invoked only a commit to the master.