### PR TITLE
Multiplexing channels for subscribed message to each device

### DIFF
--- a/app.go
+++ b/app.go
@@ -48,7 +48,7 @@ func StartByFileWithChannel(conf inidef.Config, commandChannel chan string) erro
 	if err != nil {
 		log.Fatalf("broker(s) create error, %v", err)
 	}
-	deviceList, err := device.NewDevices(conf, brokerList, gw.DeviceChannels)
+	deviceList, deviceChannels, err := device.NewDevices(conf, brokerList, gw.DeviceChannels)
 	if err != nil {
 		log.Fatalf("device create error, %v", err)
 	}
@@ -56,6 +56,7 @@ func StartByFileWithChannel(conf inidef.Config, commandChannel chan string) erro
 	gw.Devices = deviceList
 	gw.Brokers = brokerList
 	gw.CmdChan = commandChannel
+	gw.DeviceChannels = deviceChannels
 
 	status, err := device.NewStatus(conf)
 	if err != nil {

--- a/app.go
+++ b/app.go
@@ -48,7 +48,7 @@ func StartByFileWithChannel(conf inidef.Config, commandChannel chan string) erro
 	if err != nil {
 		log.Fatalf("broker(s) create error, %v", err)
 	}
-	deviceList, deviceChannels, err := device.NewDevices(conf, brokerList, gw.DeviceChannels)
+	deviceList, deviceChannels, err := device.NewDevices(conf, brokerList)
 	if err != nil {
 		log.Fatalf("device create error, %v", err)
 	}

--- a/app.go
+++ b/app.go
@@ -48,7 +48,7 @@ func StartByFileWithChannel(conf inidef.Config, commandChannel chan string) erro
 	if err != nil {
 		log.Fatalf("broker(s) create error, %v", err)
 	}
-	deviceList, err := device.NewDevices(conf, brokerList, gw.DeviceChan)
+	deviceList, err := device.NewDevices(conf, brokerList, gw.DeviceChannels)
 	if err != nil {
 		log.Fatalf("device create error, %v", err)
 	}

--- a/device/device.go
+++ b/device/device.go
@@ -30,8 +30,9 @@ type Devicer interface {
 }
 
 // NewDevices is a factory method to create various kind of devices from ini.File
-func NewDevices(conf inidef.Config, brokers []*broker.Broker, devChannels []DeviceChannel) ([]Devicer, []DeviceChannel, error) {
+func NewDevices(conf inidef.Config, brokers []*broker.Broker) ([]Devicer, []DeviceChannel, error) {
 	var ret []Devicer
+	var devChannels []DeviceChannel
 
 	var err error
 	for _, section := range conf.Sections {

--- a/device/device.go
+++ b/device/device.go
@@ -30,7 +30,7 @@ type Devicer interface {
 }
 
 // NewDevices is a factory method to create various kind of devices from ini.File
-func NewDevices(conf inidef.Config, brokers []*broker.Broker, devChannels []DeviceChannel) ([]Devicer, error) {
+func NewDevices(conf inidef.Config, brokers []*broker.Broker, devChannels []DeviceChannel) ([]Devicer, []DeviceChannel, error) {
 	var ret []Devicer
 
 	var err error
@@ -64,5 +64,5 @@ func NewDevices(conf inidef.Config, brokers []*broker.Broker, devChannels []Devi
 		ret = append(ret, device)
 	}
 
-	return ret, nil
+	return ret, devChannels, nil
 }

--- a/device/device.go
+++ b/device/device.go
@@ -30,7 +30,7 @@ type Devicer interface {
 }
 
 // NewDevices is a factory method to create various kind of devices from ini.File
-func NewDevices(conf inidef.Config, brokers []*broker.Broker, devChan chan message.Message) ([]Devicer, error) {
+func NewDevices(conf inidef.Config, brokers []*broker.Broker, devChannels []DeviceChannel) ([]Devicer, error) {
 	var ret []Devicer
 
 	var err error
@@ -40,6 +40,10 @@ func NewDevices(conf inidef.Config, brokers []*broker.Broker, devChan chan messa
 		}
 
 		var device Devicer
+
+		devChan := NewDeviceChannel()
+		devChannels = append(devChannels, devChan)
+
 		switch section.Arg {
 		case "dummy":
 			device, err = NewDummyDevice(section, brokers, devChan)

--- a/device/deviceChannel.go
+++ b/device/deviceChannel.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	MaxDeviceChanBufferSize	= 20
+	MaxDeviceChanBufferSize = 20
 )
 
 type DeviceChannel struct {
@@ -34,7 +34,7 @@ func NewDeviceChannel() DeviceChannel {
 	return ch
 }
 
-func NewDeviceChannels() ([]DeviceChannel) {
+func NewDeviceChannels() []DeviceChannel {
 	channels := []DeviceChannel{}
 	return channels
 }

--- a/device/deviceChannel.go
+++ b/device/deviceChannel.go
@@ -26,7 +26,7 @@ type DeviceChannel struct {
 	Chan chan message.Message
 }
 
-// NewDeviceChan is a factory method to return DeviceChannel
+// NewDeviceChannel is a factory method to return DeviceChannel
 func NewDeviceChannel() DeviceChannel {
 	ch := DeviceChannel{
 		Chan: make(chan message.Message, MaxDeviceChanBufferSize),

--- a/device/deviceChannel.go
+++ b/device/deviceChannel.go
@@ -1,0 +1,40 @@
+// Copyright 2015 Shiguredo Inc. <fuji@shiguredo.jp>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package device
+
+import (
+	"github.com/shiguredo/fuji/message"
+)
+
+const (
+	MaxDeviceChanBufferSize	= 20
+)
+
+type DeviceChannel struct {
+	Chan chan message.Message
+}
+
+// NewDeviceChan is a factory method to return DeviceChannel
+func NewDeviceChannel() DeviceChannel {
+	ch := DeviceChannel{
+		Chan: make(chan message.Message, MaxDeviceChanBufferSize),
+	}
+	return ch
+}
+
+func NewDeviceChannels() ([]DeviceChannel) {
+	channels := []DeviceChannel{}
+	return channels
+}

--- a/device/dummy.go
+++ b/device/dummy.go
@@ -41,7 +41,7 @@ type DummyDevice struct {
 	Type       string `validate:"max=256"`
 	Retain     bool
 	Subscribe  bool
-	DeviceChan chan message.Message // GW -> device
+	DeviceChan DeviceChannel	// GW -> device
 }
 
 // String retruns dummy device information
@@ -50,7 +50,7 @@ func (dummyDevice *DummyDevice) String() string {
 }
 
 // NewDummyDevice creates dummy device which outputs specified string/binary payload.
-func NewDummyDevice(section inidef.ConfigSection, brokers []*broker.Broker, devChan chan message.Message) (DummyDevice, error) {
+func NewDummyDevice(section inidef.ConfigSection, brokers []*broker.Broker, devChan DeviceChannel) (DummyDevice, error) {
 	ret := DummyDevice{
 		Name:       section.Name,
 		DeviceChan: devChan,
@@ -138,7 +138,7 @@ func (device DummyDevice) MainLoop(channel chan message.Message) error {
 				BrokerName: device.BrokerName,
 			}
 			channel <- msg
-		case msg, _ := <-device.DeviceChan:
+		case msg, _ := <- device.DeviceChan.Chan:
 			if !strings.HasSuffix(msg.Topic, device.Name) {
 				continue
 			}

--- a/device/dummy.go
+++ b/device/dummy.go
@@ -41,7 +41,7 @@ type DummyDevice struct {
 	Type       string `validate:"max=256"`
 	Retain     bool
 	Subscribe  bool
-	DeviceChan DeviceChannel	// GW -> device
+	DeviceChan DeviceChannel // GW -> device
 }
 
 // String retruns dummy device information
@@ -138,7 +138,7 @@ func (device DummyDevice) MainLoop(channel chan message.Message) error {
 				BrokerName: device.BrokerName,
 			}
 			channel <- msg
-		case msg, _ := <- device.DeviceChan.Chan:
+		case msg, _ := <-device.DeviceChan.Chan:
 			if !strings.HasSuffix(msg.Topic, device.Name) {
 				continue
 			}

--- a/device/dummy_test.go
+++ b/device/dummy_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/shiguredo/fuji/broker"
 	"github.com/shiguredo/fuji/inidef"
-	"github.com/shiguredo/fuji/message"
 )
 
 func TestNewDummyDevice(t *testing.T) {
@@ -38,7 +37,7 @@ func TestNewDummyDevice(t *testing.T) {
 	conf, err := inidef.LoadConfigByte([]byte(iniStr))
 	b1 := &broker.Broker{Name: "sango"}
 	brokers := []*broker.Broker{b1}
-	b, err := NewDummyDevice(conf.Sections[1], brokers, make(chan message.Message))
+	b, err := NewDummyDevice(conf.Sections[1], brokers, NewDeviceChannel())
 	assert.Nil(err)
 	assert.NotNil(b.Broker)
 	assert.Equal("dora", b.Name)
@@ -59,7 +58,7 @@ func TestNewDummyDeviceInvalidInterval(t *testing.T) {
 	conf, err := inidef.LoadConfigByte([]byte(iniStr))
 	b1 := &broker.Broker{Name: "sango"}
 	brokers := []*broker.Broker{b1}
-	_, err = NewDummyDevice(conf.Sections[1], brokers, make(chan message.Message))
+	_, err = NewDummyDevice(conf.Sections[1], brokers, NewDeviceChannel())
 	assert.NotNil(err)
 }
 
@@ -75,7 +74,7 @@ func TestNewDummyDeviceInvalidQoS(t *testing.T) {
 	conf, err := inidef.LoadConfigByte([]byte(iniStr))
 	b1 := &broker.Broker{Name: "sango"}
 	brokers := []*broker.Broker{b1}
-	_, err = NewDummyDevice(conf.Sections[1], brokers, make(chan message.Message))
+	_, err = NewDummyDevice(conf.Sections[1], brokers, NewDeviceChannel())
 	assert.NotNil(err)
 }
 
@@ -91,6 +90,6 @@ func TestNewDummyDeviceInvalidBroker(t *testing.T) {
 	conf, err := inidef.LoadConfigByte([]byte(iniStr))
 	b1 := &broker.Broker{Name: "sango"}
 	brokers := []*broker.Broker{b1}
-	_, err = NewDummyDevice(conf.Sections[1], brokers, make(chan message.Message))
+	_, err = NewDummyDevice(conf.Sections[1], brokers, NewDeviceChannel())
 	assert.NotNil(err)
 }

--- a/device/serial.go
+++ b/device/serial.go
@@ -43,7 +43,7 @@ type SerialDevice struct {
 	Interval   int    `validate:"min=0"`
 	Retain     bool
 	Subscribe  bool
-	DeviceChan chan message.Message // GW -> device
+	DeviceChan DeviceChannel	// GW -> device
 }
 
 func (device SerialDevice) String() string {
@@ -56,7 +56,7 @@ func (device SerialDevice) String() string {
 
 // NewSerialDevice read inidef.ConfigSection and returnes SerialDevice.
 // If config validation failed, return error
-func NewSerialDevice(section inidef.ConfigSection, brokers []*broker.Broker, devChan chan message.Message) (SerialDevice, error) {
+func NewSerialDevice(section inidef.ConfigSection, brokers []*broker.Broker, devChan DeviceChannel) (SerialDevice, error) {
 	ret := SerialDevice{
 		Name:       section.Name,
 		DeviceChan: devChan,
@@ -236,7 +236,7 @@ func (device SerialDevice) Start(channel chan message.Message) error {
 					Body:       msgBuf,
 				}
 				channel <- msg
-			case msg, _ := <-device.DeviceChan:
+			case msg, _ := <- device.DeviceChan.Chan:
 				log.Infof("msg topic:, %v / %v", msg.Topic, device.Name)
 				if !strings.HasSuffix(msg.Topic, device.Name) {
 					continue

--- a/device/serial.go
+++ b/device/serial.go
@@ -43,7 +43,7 @@ type SerialDevice struct {
 	Interval   int    `validate:"min=0"`
 	Retain     bool
 	Subscribe  bool
-	DeviceChan DeviceChannel	// GW -> device
+	DeviceChan DeviceChannel // GW -> device
 }
 
 func (device SerialDevice) String() string {
@@ -236,7 +236,7 @@ func (device SerialDevice) Start(channel chan message.Message) error {
 					Body:       msgBuf,
 				}
 				channel <- msg
-			case msg, _ := <- device.DeviceChan.Chan:
+			case msg, _ := <-device.DeviceChan.Chan:
 				log.Infof("msg topic:, %v / %v", msg.Topic, device.Name)
 				if !strings.HasSuffix(msg.Topic, device.Name) {
 					continue

--- a/device/serial_test.go
+++ b/device/serial_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/shiguredo/fuji/broker"
 	"github.com/shiguredo/fuji/inidef"
-	"github.com/shiguredo/fuji/message"
 )
 
 func TestNewSerialDevice(t *testing.T) {
@@ -39,7 +38,7 @@ func TestNewSerialDevice(t *testing.T) {
 	conf, err := inidef.LoadConfigByte([]byte(iniStr))
 	b1 := &broker.Broker{Name: "sango"}
 	brokers := []*broker.Broker{b1}
-	b, err := NewSerialDevice(conf.Sections[1], brokers, make(chan message.Message))
+	b, err := NewSerialDevice(conf.Sections[1], brokers, NewDeviceChannel())
 	assert.Nil(err)
 	assert.NotNil(b.Broker)
 	assert.Equal("dora", b.Name)
@@ -62,7 +61,7 @@ func TestNewSerialDeviceNotSetSize(t *testing.T) {
 	conf, err := inidef.LoadConfigByte([]byte(iniStr))
 	b1 := &broker.Broker{Name: "sango"}
 	brokers := []*broker.Broker{b1}
-	b, err := NewSerialDevice(conf.Sections[1], brokers, make(chan message.Message))
+	b, err := NewSerialDevice(conf.Sections[1], brokers, NewDeviceChannel())
 	assert.Nil(err)
 	assert.NotNil(b.Broker)
 	assert.Equal("dora", b.Name)
@@ -82,7 +81,7 @@ func TestNewSerialDeviceInvalidInterval(t *testing.T) {
 	conf, err := inidef.LoadConfigByte([]byte(iniStr))
 	b1 := &broker.Broker{Name: "sango"}
 	brokers := []*broker.Broker{b1}
-	_, err = NewSerialDevice(conf.Sections[1], brokers, make(chan message.Message))
+	_, err = NewSerialDevice(conf.Sections[1], brokers, NewDeviceChannel())
 	assert.NotNil(err)
 }
 
@@ -97,7 +96,7 @@ func TestNewSerialDeviceInvalidQoS(t *testing.T) {
 	conf, err := inidef.LoadConfigByte([]byte(iniStr))
 	b1 := &broker.Broker{Name: "sango"}
 	brokers := []*broker.Broker{b1}
-	_, err = NewSerialDevice(conf.Sections[1], brokers, make(chan message.Message))
+	_, err = NewSerialDevice(conf.Sections[1], brokers, NewDeviceChannel())
 	assert.NotNil(err)
 }
 
@@ -112,7 +111,7 @@ func TestNewSerialDeviceInvalidBroker(t *testing.T) {
 	conf, err := inidef.LoadConfigByte([]byte(iniStr))
 	b1 := &broker.Broker{Name: "sango"}
 	brokers := []*broker.Broker{b1}
-	_, err = NewSerialDevice(conf.Sections[1], brokers, make(chan message.Message))
+	_, err = NewSerialDevice(conf.Sections[1], brokers, NewDeviceChannel())
 	assert.NotNil(err)
 }
 
@@ -128,7 +127,7 @@ func TestNewSerialDeviceInvalidBaud(t *testing.T) {
 	conf, err := inidef.LoadConfigByte([]byte(iniStr))
 	b1 := &broker.Broker{Name: "sango"}
 	brokers := []*broker.Broker{b1}
-	_, err = NewSerialDevice(conf.Sections[1], brokers, make(chan message.Message))
+	_, err = NewSerialDevice(conf.Sections[1], brokers, NewDeviceChannel())
 	assert.NotNil(err)
 }
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -38,10 +38,10 @@ type Gateway struct {
 	Devices []device.Devicer
 	Brokers broker.Brokers
 
-	MsgChan    chan message.Message // Broker -> GW
-	BrokerChan chan message.Message // GW -> Broker
-	CmdChan    chan string          // somewhere -> GW
-	DeviceChannels []device.DeviceChannel	// GW -> device
+	MsgChan        chan message.Message   // Broker -> GW
+	BrokerChan     chan message.Message   // GW -> Broker
+	CmdChan        chan string            // somewhere -> GW
+	DeviceChannels []device.DeviceChannel // GW -> device
 
 	MaxRetryCount int `validate:"min=1"`
 	RetryInterval int `validate:"min=1"`
@@ -75,13 +75,13 @@ func NewGateway(conf inidef.Config) (*Gateway, error) {
 	}
 
 	gw := Gateway{
-		Name:          section.Values["name"],
-		MsgChan:       make(chan message.Message, MaxMsgChanBufferSize),
-		BrokerChan:    make(chan message.Message, MaxBrokerChanBufferSize),
-		DeviceChannels:    device.NewDeviceChannels(),
-		CmdChan:       make(chan string),
-		MaxRetryCount: DefaultMaxRetryCount,
-		RetryInterval: DefaultRetryInterval,
+		Name:           section.Values["name"],
+		MsgChan:        make(chan message.Message, MaxMsgChanBufferSize),
+		BrokerChan:     make(chan message.Message, MaxBrokerChanBufferSize),
+		DeviceChannels: device.NewDeviceChannels(),
+		CmdChan:        make(chan string),
+		MaxRetryCount:  DefaultMaxRetryCount,
+		RetryInterval:  DefaultRetryInterval,
 	}
 
 	if m, ok := section.Values["max_retry_count"]; ok {

--- a/tests/connect_test.go
+++ b/tests/connect_test.go
@@ -62,7 +62,7 @@ func TestConnectLocalPubSub(t *testing.T) {
 	assert.Nil(err)
 
 	// get DummyDevice
-	dummyDevice, err := device.NewDummyDevice(conf.Sections[3], brokerList, gw.DeviceChan)
+	dummyDevice, err := device.NewDummyDevice(conf.Sections[3], brokerList, device.NewDeviceChannel())
 	assert.Nil(err)
 	assert.NotNil(dummyDevice)
 

--- a/tests/ini_retain_test.go
+++ b/tests/ini_retain_test.go
@@ -147,7 +147,7 @@ func generalIniRetainSerialDeviceTest(test iniRetainTestCase, t *testing.T) {
 	brokers, err := broker.NewBrokers(conf, make(chan message.Message))
 	assert.Nil(err)
 
-	devices, err := device.NewDevices(conf, brokers, make(chan message.Message))
+	devices, _, err := device.NewDevices(conf, brokers)
 	assert.Nil(err)
 	assert.Equal(1, len(devices))
 }
@@ -162,7 +162,7 @@ func generalIniRetainDummyDeviceTest(test iniRetainTestCase, t *testing.T) {
 	brokers, err := broker.NewBrokers(conf, make(chan message.Message))
 	assert.Nil(err)
 
-	dummy, err := device.NewDummyDevice(conf.Sections[2], brokers, make(chan message.Message))
+	dummy, err := device.NewDummyDevice(conf.Sections[2], brokers, device.NewDeviceChannel())
 	if test.expectedError == nil {
 		assert.Nil(err)
 		assert.NotNil(dummy)

--- a/tests/ini_test.go
+++ b/tests/ini_test.go
@@ -59,7 +59,7 @@ func TestIniNewSerialDevices(t *testing.T) {
 	conf, err := inidef.LoadConfig("testing_conf.ini")
 	brokerList, err := broker.NewBrokers(conf, make(chan message.Message))
 	assert.Nil(err)
-	deviceList, err := device.NewDevices(conf, brokerList, make(chan message.Message))
+	deviceList, _, err := device.NewDevices(conf, brokerList)
 	assert.Nil(err)
 	assert.Equal(3, len(deviceList))
 }
@@ -71,7 +71,7 @@ func TestIniNewDummyDevice(t *testing.T) {
 	brokerList, err := broker.NewBrokers(conf, make(chan message.Message))
 	assert.Nil(err)
 
-	dummy, err := device.NewDummyDevice(conf.Sections[7], brokerList, make(chan message.Message))
+	dummy, err := device.NewDummyDevice(conf.Sections[7], brokerList, device.NewDeviceChannel())
 	assert.Nil(err)
 	assert.Equal("dummy", dummy.DeviceType())
 	assert.Equal(2, int(dummy.QoS))

--- a/tests/retain_test.go
+++ b/tests/retain_test.go
@@ -107,7 +107,9 @@ func TestRetainSubscribePublishClose(t *testing.T) {
 		t.Error("Cannot make BrokerList")
 	}
 
-	dummyDevice, err := device.NewDummyDevice(conf.Sections[3], brokerList, gw.DeviceChan)
+	devChan := device.NewDeviceChannel()
+	gw.DeviceChannels = append(gw.DeviceChannels, devChan)
+	dummyDevice, err := device.NewDummyDevice(conf.Sections[3], brokerList, devChan)
 	if err != nil {
 		t.Error("Cannot make DummyDeviceList")
 	}


### PR DESCRIPTION

## Before:

```
  Subscribed message from Broker -> Gateway -> single channel for all devices ---> dummy device, serial device ...
```
Thus, only one device can receive subscribed message. If other device is specified in the configuration, it might lose message.

## After:

```
  Subscribed message from Broker -> Gateway ---> slice of channels for each device
```
More than 1 devices can receive subscribed message. Topic filtering is done on each device. 

## Impatct

### Following public API are modified.

- fuji.device.NewDevices() 
- fuji.device.NewDummyDevice(), fuji.device.DummyDevice type
- fuji.device.NewSerialDevice(), fuji.device.SerialDevice type
- fuji.gateway.Gateway type

### New API definitions
- fuji.device.NewDeviceChannel(), fuji.device.DeviceChannel type

### tests to be modified
Some tests need to be modified to accmodate API change.

- tests/connect_test.go
- tests/ini_retain_test.go
- tests/ini_test.go
- tests/retain_test.go