### PR TITLE
make: added fmt target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,15 @@ SUDOPATH=${PATH}
 
 all: build test raspi raspi2 edison armadillo
 
-doc:
+fmt:
 	go fmt ./...
+
+doc: fmt
 #	golint ./...
 	go build github.com/shiguredo/fuji/cmd/fuji
 	godoc github.com/shiguredo/fuji
 
-build: deps
-	go fmt ./...
+build: fmt deps
 #	golint ./...
 	go build
 	go build $(LDFLAGS) github.com/shiguredo/fuji/cmd/fuji


### PR DESCRIPTION
Simplified Makefile a bit. And it is useful when we want to run only `go fmt ./...`.