### PR TITLE
build: generated TAG from git-describe.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ FPM = fpm
 REPO="github.com/shiguredo/fuji/cmd/fuji"
 TEST_LIST := tests
 
-TAG=0.2.3
+TAG=`git describe --abbrev=0 --tags`
 ARTIFACTS=downloads
 BUILDDIR=build
 LDFLAGS=-ldflags "-X main.version `git describe --tags --always`"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ FPM = fpm
 REPO="github.com/shiguredo/fuji/cmd/fuji"
 TEST_LIST := tests
 
-TAG=`git describe --abbrev=0 --tags`
+TAG=$(shell git describe --abbrev=0 --tags)
 ARTIFACTS=downloads
 BUILDDIR=build
 LDFLAGS=-ldflags "-X main.version `git describe --tags --always`"

--- a/README.rst
+++ b/README.rst
@@ -84,10 +84,9 @@ How To Release
 ==================
 
 1. git flow release start x.y.z
-2. update TAG in Makefile
-3. update CHANGELOG.rst
-4. git flow release finish x.y.z
-5. git push
+2. update CHANGELOG.rst
+3. git flow release finish x.y.z
+4. git push
 
 License
 ========


### PR DESCRIPTION
Automated tag-generation in `Makefile`. We can skip `update TAG in Makefile` in the release process.
