### PR TITLE
build: used `git rev-parse` instead of `git describe`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@ REPO="github.com/shiguredo/fuji/cmd/fuji"
 TEST_LIST := tests
 
 TAG=0.2.3
+REV=`git rev-parse HEAD | cut -c1-7`
 ARTIFACTS=downloads
 BUILDDIR=build
-LDFLAGS=-ldflags "-X main.version `git describe --tags --always`"
+LDFLAGS=-ldflags "-X main.version ${TAG}-${REV}"
 
 ALL_LIST = $(TEST_LIST)
 


### PR DESCRIPTION
`git describe` is possible to get old tag by mistake.
Because git describe cannot get latest tag tagged on
different branch. (e.g. master or develop)

The output with `-v` is slightly changed by this change.

```
$ fuji -v
fuji-gw version 0.2.3-7ea4421
Compiler: gc go1.5.1
Copyright 2015 Shiguredo Inc. <fuji@shiguredo.jp>
```

refs #11 