### PR TITLE
add: will_topic configuration capability

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -44,6 +44,7 @@ type Broker struct {
 	RetryInterval int    `validate:"min=0"`
 	TopicPrefix   string `validate:"max=256"`
 	WillMessage   []byte `validate:"max=256"`
+	WillTopic     string `validate:"max=256,validtopic"`
 	Tls           bool
 	CaCert        string `validate:"max=256"`
 	TLSConfig     *tls.Config
@@ -165,6 +166,11 @@ func NewBrokers(conf inidef.Config, gwChan chan message.Message) (Brokers, error
 			}
 		}
 
+		if values["will_topic"] != "" {
+			broker.WillTopic = strings.Join([]string{broker.TopicPrefix, values["will_topic"]}, "/")
+		} else {
+			broker.WillTopic = strings.Join([]string{broker.TopicPrefix, broker.GatewayName, "will"}, "/")
+		}
 		// Validation
 		if err := validator.Validate(broker); err != nil {
 			return brokers, err
@@ -309,7 +315,7 @@ func MQTTConnect(gwName string, b *Broker) (*MQTT.Client, error) {
 	opts.SetUsername(b.Username)
 	opts.SetPassword(b.Password)
 	if !inidef.IsNil(b.WillMessage) {
-		willTopic := strings.Join([]string{b.TopicPrefix, gwName, "will"}, "/")
+		willTopic := b.WillTopic
 		willQoS := 0
 		opts.SetBinaryWill(willTopic, b.WillMessage, byte(willQoS), true)
 	}

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -33,6 +33,10 @@ import (
 	"github.com/shiguredo/fuji/utils"
 )
 
+const (
+	defaultWillTopic = "will"
+)
+
 type Broker struct {
 	GatewayName   string
 	Name          string `validate:"max=256,regexp=[^/]+,validtopic"`
@@ -169,7 +173,7 @@ func NewBrokers(conf inidef.Config, gwChan chan message.Message) (Brokers, error
 		if values["will_topic"] != "" {
 			broker.WillTopic = strings.Join([]string{broker.TopicPrefix, values["will_topic"]}, "/")
 		} else {
-			broker.WillTopic = strings.Join([]string{broker.TopicPrefix, broker.GatewayName, "will"}, "/")
+			broker.WillTopic = strings.Join([]string{broker.TopicPrefix, broker.GatewayName, defaultWillTopic}, "/")
 		}
 		// Validation
 		if err := validator.Validate(broker); err != nil {

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -140,12 +140,6 @@ func TestWillSubscribePublishWillWithWillTopic(t *testing.T) {
 	    port = 1883
 	    will_message = msg
 	    will_topic = willtopic
-	[device "dora/dummy"]
-	    broker = local
-	    qos = 0
-	    interval = 10
-	    payload = Hello will just publish world.
-	    type = EnOcean
 `
 	ok := genericWillTestDriver(t, iniStr, "/willtopic", []byte("msg"))
 	if !ok {
@@ -162,12 +156,6 @@ func TestWillSubscribePublishWillWithNestedWillTopic(t *testing.T) {
 	    port = 1883
 	    will_message = msg
 	    will_topic = willtopic/nested
-	[device "dora/dummy"]
-	    broker = local
-	    qos = 0
-	    interval = 10
-	    payload = Hello will just publish world.
-	    type = EnOcean
 `
 	ok := genericWillTestDriver(t, iniStr, "/willtopic/nested", []byte("msg"))
 	if !ok {

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -131,6 +131,50 @@ func TestWillSubscribePublishBinaryWill(t *testing.T) {
 	}
 }
 
+func TestWillSubscribePublishWillWithWillTopic(t *testing.T) {
+	iniStr := `
+	[gateway]
+	    name = with
+	[broker "local/1"]
+	    host = localhost
+	    port = 1883
+	    will_message = msg
+	    will_topic = willtopic
+	[device "dora/dummy"]
+	    broker = local
+	    qos = 0
+	    interval = 10
+	    payload = Hello will just publish world.
+	    type = EnOcean
+`
+	ok := genericWillTestDriver(t, iniStr, "/willtopic", []byte("msg"))
+	if !ok {
+		t.Error("Failed to receive Empty Will message")
+	}
+}
+
+func TestWillSubscribePublishWillWithNestedWillTopic(t *testing.T) {
+	iniStr := `
+	[gateway]
+	    name = with
+	[broker "local/1"]
+	    host = localhost
+	    port = 1883
+	    will_message = msg
+	    will_topic = willtopic/nested
+	[device "dora/dummy"]
+	    broker = local
+	    qos = 0
+	    interval = 10
+	    payload = Hello will just publish world.
+	    type = EnOcean
+`
+	ok := genericWillTestDriver(t, iniStr, "/willtopic/nested", []byte("msg"))
+	if !ok {
+		t.Error("Failed to receive Empty Will message")
+	}
+}
+
 // genericWillTestDriver
 // 1. read config string
 // 2. connect subscriber and publisher to localhost broker with will message


### PR DESCRIPTION
Add feature to set any topicstring as a will topic.
Unless specified within broker clause of configuration file, default value is set as /{gateway name}/will 