### PR TITLE
enhancement: use a client certificate to establish a TLS connection

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -106,6 +106,9 @@ func NewTLSConfig(b *Broker) (*tls.Config, error) {
 		InsecureSkipVerify: true,
 	}
 	if b.ClientCert != "" {
+		if b.ClientKey == "" {
+			return nil, config.Error("Client certificate requires private key")
+		}
 		// client certificate also checked
 		cert, err := tls.LoadX509KeyPair(b.ClientCert, b.ClientKey)
 		if err != nil {

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -52,6 +52,8 @@ type Broker struct {
 	WillTopic     string `validate:"max=256,validtopic"`
 	Tls           bool
 	CaCert        string `validate:"max=256"`
+	ClientCert    string `validate:"max=256"`
+	ClientKey     string `validate:"max=256"`
 	TLSConfig     *tls.Config
 	Subscribed    Subscribed // list of subscribed topics
 
@@ -89,22 +91,31 @@ func NewTLSConfig(b *Broker) (*tls.Config, error) {
 	certPool := x509.NewCertPool()
 	pemCerts, err := ioutil.ReadFile(b.CaCert)
 	if err != nil {
-		return nil, config.Error("Cert File could not be read.")
+		return nil, config.Error(fmt.Sprintf("Cert File: %s could not be read.", b.CaCert))
 	}
 	appendCertOk := certPool.AppendCertsFromPEM(pemCerts)
 	if appendCertOk != true {
 		return nil, config.Error("Server Certificate parse failed")
 	}
-
-	// only server certificate checked
-	return &tls.Config{
+	ret := &tls.Config{
 		RootCAs:    certPool,
 		ClientAuth: tls.NoClientCert,
 		ClientCAs:  nil,
 		// InsecureSkipVerify = verify that cert contents
 		// match server. IP matches what is in cert etc.
 		InsecureSkipVerify: true,
-	}, nil
+	}
+	if b.ClientCert != "" {
+		// client certificate also checked
+		cert, err := tls.LoadX509KeyPair(b.ClientCert, b.ClientKey)
+		if err != nil {
+			return nil, err
+		}
+		ret.ClientAuth = tls.RequireAndVerifyClientCert
+		ret.Certificates = []tls.Certificate{cert}
+		ret.ClientCAs = certPool
+	}
+	return ret, nil
 }
 
 // NewBrokers returns []*Broker from config.Config.
@@ -179,9 +190,18 @@ func NewBrokers(conf config.Config, gwChan chan message.Message) (Brokers, error
 			if values["cacert"] == "" {
 				return nil, fmt.Errorf("cacert must be set")
 			}
-			// validate certificate
 			broker.Tls = true
 			broker.CaCert = values["cacert"]
+
+			// check client certificate
+			if values["client_cert"] != "" && values["client_key"] != "" {
+				// client certificate authentication
+
+				broker.ClientCert = values["client_cert"]
+				broker.ClientKey = values["client_key"]
+			}
+
+			// validate certificate
 			broker.TLSConfig, err = NewTLSConfig(broker)
 			if err != nil {
 				return nil, err
@@ -336,7 +356,7 @@ func MQTTConnect(gwName string, b *Broker) (*MQTT.Client, error) {
 
 	opts.SetUsername(b.Username)
 	opts.SetPassword(b.Password)
-	if !config.IsNil(b.WillMessage) {
+	if b.IsWill {
 		willTopic := b.WillTopic
 		willQoS := 0
 		opts.SetBinaryWill(willTopic, b.WillMessage, byte(willQoS), true)

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,8 @@ test:
     - docker run -d -p 1883:1883 -p 8883:8883 -p 9883:9883 -p 8080:8080 -v /home/ubuntu/.go_workspace/src/github.com/shiguredo/fuji/tests/mosquitto:/mosquitto --name fuji-test-mosquitto shiguredo/mosquitto ; sleep 20
     - godep go build:
         pwd: ../.go_workspace/src/${REPO_PATH}
+    - make build:
+        pwd: ../.go_workspace/src/${REPO_PATH}
     - godep go test -coverpkg github.com/shiguredo/fuji ./...:
         pwd: ../.go_workspace/src/${REPO_PATH}
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ test:
   override:
     - go version
     - go get -u github.com/mitchellh/gox
-    - docker run -d -p 1883:1883 -p 8883:8883 -p 8080:8080 -v /home/ubuntu/.go_workspace/src/github.com/shiguredo/fuji/tests/mosquitto:/mosquitto --name fuji-test-mosquitto shiguredo/mosquitto ; sleep 20
+    - docker run -d -p 1883:1883 -p 8883:8883 -p 9883:9883 -p 8080:8080 -v /home/ubuntu/.go_workspace/src/github.com/shiguredo/fuji/tests/mosquitto:/mosquitto --name fuji-test-mosquitto shiguredo/mosquitto ; sleep 20
     - godep go build:
         pwd: ../.go_workspace/src/${REPO_PATH}
     - godep go test -coverpkg github.com/shiguredo/fuji ./...:

--- a/tests/tls_clientcert_test.go
+++ b/tests/tls_clientcert_test.go
@@ -46,7 +46,7 @@ var tlsClientCertconfigStr = `
     retry_interval = 10
 
 
-[[device."dora"]]
+[device."dora"]
     type = "dummy"
 
     broker = "mosquitto"

--- a/tests/tls_clientcert_test.go
+++ b/tests/tls_clientcert_test.go
@@ -1,0 +1,138 @@
+// Copyright 2015 Shiguredo Inc. <fuji@shiguredo.jp>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	MQTT "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/shiguredo/fuji"
+	"github.com/shiguredo/fuji/broker"
+	"github.com/shiguredo/fuji/config"
+	"github.com/shiguredo/fuji/device"
+	"github.com/shiguredo/fuji/gateway"
+)
+
+var tlsClientCertconfigStr = `
+[gateway]
+
+    name = "tlsccerthamlocalconnect"
+
+[[broker."mosquitto/1"]]
+
+    host = "localhost"
+    port = 9883
+    tls = true
+    cacert = "mosquitto/ca.pem"
+    client_cert = "mosquitto/client.pem"
+    client_key = "mosquitto/client.key"
+
+    retry_interval = 10
+
+
+[[device."dora"]]
+    type = "dummy"
+
+    broker = "mosquitto"
+    qos = 0
+
+    interval = 10
+    payload = "connect local pub only Hello world."
+`
+
+// TestTLSConnectLocalPub
+func TestTLSClientCertConnectLocalPub(t *testing.T) {
+	assert := assert.New(t)
+
+	conf, err := config.LoadConfigByte([]byte(tlsClientCertconfigStr))
+	assert.Nil(err)
+	commandChannel := make(chan string)
+	go fuji.StartByFileWithChannel(conf, commandChannel)
+	time.Sleep(2 * time.Second)
+
+}
+
+// TestTLSConnectLocalPubSub
+// 1. connect gateway to local broker with TLS
+// 2. send data from dummy
+// 3. check subscribe
+func TestTLSClientCertConnectLocalPubSub(t *testing.T) {
+	assert := assert.New(t)
+
+	// pub/sub test to broker on localhost
+	// dummydevice is used as a source of published message
+	// publised messages confirmed by subscriber
+
+	// get config
+	conf, err := config.LoadConfigByte([]byte(tlsClientCertconfigStr))
+	assert.Nil(err)
+
+	// get Gateway
+	gw, err := gateway.NewGateway(conf)
+	assert.Nil(err)
+
+	// get Broker
+	brokerList, err := broker.NewBrokers(conf, gw.BrokerChan)
+	assert.Nil(err)
+
+	// get DummyDevice
+	dummyDevice, err := device.NewDummyDevice(conf.Sections[2], brokerList, device.NewDeviceChannel())
+	assert.Nil(err)
+	assert.NotNil(dummyDevice)
+
+	// Setup MQTT pub/sub client to confirm published content.
+	//
+	subscriberChannel := make(chan [2]string)
+
+	opts := MQTT.NewClientOptions()
+	url := fmt.Sprintf("ssl://%s:%d", brokerList[0].Host, brokerList[0].Port)
+	opts.AddBroker(url)
+	opts.SetClientID(fmt.Sprintf("prefix%s", gw.Name))
+	opts.SetCleanSession(false)
+
+	tlsConfig, err := broker.NewTLSConfig(brokerList[0])
+	assert.Nil(err)
+	opts.SetTLSConfig(tlsConfig)
+
+	client := MQTT.NewClient(opts)
+	assert.Nil(err)
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		assert.Nil(token.Error())
+		fmt.Println(token.Error())
+	}
+
+	qos := 0
+	expectedTopic := fmt.Sprintf("/%s/%s/%s/publish", gw.Name, dummyDevice.Name, dummyDevice.Type)
+	expectedMessage := fmt.Sprintf("%s", dummyDevice.Payload)
+	fmt.Printf("expetcted topic: %s\nexpected message%s", expectedTopic, expectedMessage)
+	client.Subscribe(expectedTopic, byte(qos), func(client *MQTT.Client, msg MQTT.Message) {
+		subscriberChannel <- [2]string{msg.Topic(), string(msg.Payload())}
+	})
+
+	// wait for 1 publication of dummy worker
+	select {
+	case message := <-subscriberChannel:
+		assert.Equal(expectedTopic, message[0])
+		assert.Equal(expectedMessage, message[1])
+	case <-time.After(time.Second * 11):
+		assert.Equal("subscribe completed in 11 sec", "not completed")
+	}
+
+	client.Disconnect(20)
+}

--- a/tests/tls_clientcert_test.go
+++ b/tests/tls_clientcert_test.go
@@ -120,7 +120,7 @@ func TestTLSClientCertConnectLocalPubSub(t *testing.T) {
 	qos := 0
 	expectedTopic := fmt.Sprintf("/%s/%s/%s/publish", gw.Name, dummyDevice.Name, dummyDevice.Type)
 	expectedMessage := fmt.Sprintf("%s", dummyDevice.Payload)
-	t.Log(fmt.Sprintf("expetcted topic: %s\nexpected message%s", expectedTopic, expectedMessage))
+	t.Logf("expetcted topic: %s\nexpected message%s", expectedTopic, expectedMessage)
 	client.Subscribe(expectedTopic, byte(qos), func(client *MQTT.Client, msg MQTT.Message) {
 		subscriberChannel <- [2]string{msg.Topic(), string(msg.Payload())}
 	})

--- a/tests/tls_clientcert_test.go
+++ b/tests/tls_clientcert_test.go
@@ -114,13 +114,13 @@ func TestTLSClientCertConnectLocalPubSub(t *testing.T) {
 	assert.Nil(err)
 	if token := client.Connect(); token.Wait() && token.Error() != nil {
 		assert.Nil(token.Error())
-		fmt.Println(token.Error())
+		t.Log(token.Error())
 	}
 
 	qos := 0
 	expectedTopic := fmt.Sprintf("/%s/%s/%s/publish", gw.Name, dummyDevice.Name, dummyDevice.Type)
 	expectedMessage := fmt.Sprintf("%s", dummyDevice.Payload)
-	fmt.Printf("expetcted topic: %s\nexpected message%s", expectedTopic, expectedMessage)
+	t.Log(fmt.Sprintf("expetcted topic: %s\nexpected message%s", expectedTopic, expectedMessage))
 	client.Subscribe(expectedTopic, byte(qos), func(client *MQTT.Client, msg MQTT.Message) {
 		subscriberChannel <- [2]string{msg.Topic(), string(msg.Payload())}
 	})

--- a/tests/tls_connect_test.go
+++ b/tests/tls_connect_test.go
@@ -118,7 +118,7 @@ func TestTLSConnectLocalPubSub(t *testing.T) {
 	qos := 0
 	expectedTopic := fmt.Sprintf("/%s/%s/%s/publish", gw.Name, dummyDevice.Name, dummyDevice.Type)
 	expectedMessage := fmt.Sprintf("%s", dummyDevice.Payload)
-	t.Log(fmt.Sprintf("expetcted topic: %s\nexpected message%s", expectedTopic, expectedMessage))
+	t.Logf("expetcted topic: %s\nexpected message%s", expectedTopic, expectedMessage)
 	client.Subscribe(expectedTopic, byte(qos), func(client *MQTT.Client, msg MQTT.Message) {
 		subscriberChannel <- [2]string{msg.Topic(), string(msg.Payload())}
 	})

--- a/tests/tls_connect_test.go
+++ b/tests/tls_connect_test.go
@@ -112,13 +112,13 @@ func TestTLSConnectLocalPubSub(t *testing.T) {
 	assert.Nil(err)
 	if token := client.Connect(); token.Wait() && token.Error() != nil {
 		assert.Nil(token.Error())
-		fmt.Println(token.Error())
+		t.Log(token.Error())
 	}
 
 	qos := 0
 	expectedTopic := fmt.Sprintf("/%s/%s/%s/publish", gw.Name, dummyDevice.Name, dummyDevice.Type)
 	expectedMessage := fmt.Sprintf("%s", dummyDevice.Payload)
-	fmt.Printf("expetcted topic: %s\nexpected message%s", expectedTopic, expectedMessage)
+	t.Log(fmt.Sprintf("expetcted topic: %s\nexpected message%s", expectedTopic, expectedMessage))
 	client.Subscribe(expectedTopic, byte(qos), func(client *MQTT.Client, msg MQTT.Message) {
 		subscriberChannel <- [2]string{msg.Topic(), string(msg.Payload())}
 	})

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -305,7 +305,7 @@ func genericWillTestDriver(t *testing.T, configStr string, expectedTopic string,
 	if err != nil {
 		t.Error(err)
 	}
-	fmt.Println("broker killed for getting will message")
+	t.Log("broker killed for getting will message")
 
 	ok = <-fin
 	return ok

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -327,7 +327,7 @@ func setupWillSubscriber(gw *gateway.Gateway, broker *broker.Broker, t *testing.
 	})
 	willQoS := 0
 	willTopic := broker.WillTopic
-	t.Log(fmt.Sprintf("expected will_topic: %s", willTopic))
+	t.Logf("expected will_topic: %s", willTopic)
 
 	client := MQTT.NewClient(opts)
 	if client == nil {

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -269,7 +269,7 @@ func genericWillTestDriver(t *testing.T, configStr string, expectedTopic string,
 	brokers, err := broker.NewBrokers(conf, gw.BrokerChan)
 	assert.Nil(err)
 
-	subscriberChannel, err := setupWillSubscriber(gw, brokers[0])
+	subscriberChannel, err := setupWillSubscriber(gw, brokers[0], t)
 	if err != config.Error("") {
 		t.Error(err)
 	}
@@ -312,7 +312,7 @@ func genericWillTestDriver(t *testing.T, configStr string, expectedTopic string,
 }
 
 // setupWillSubscriber start subscriber process and returnes a channel witch can receive will message.
-func setupWillSubscriber(gw *gateway.Gateway, broker *broker.Broker) (chan MQTT.Message, config.Error) {
+func setupWillSubscriber(gw *gateway.Gateway, broker *broker.Broker, t *testing.T) (chan MQTT.Message, config.Error) {
 	// Setup MQTT pub/sub client to confirm published content.
 	//
 	messageOutputChannel := make(chan MQTT.Message)
@@ -327,7 +327,7 @@ func setupWillSubscriber(gw *gateway.Gateway, broker *broker.Broker) (chan MQTT.
 	})
 	willQoS := 0
 	willTopic := broker.WillTopic
-	fmt.Printf("expected will_topic: %s", willTopic)
+	t.Log(fmt.Sprintf("expected will_topic: %s", willTopic))
 
 	client := MQTT.NewClient(opts)
 	if client == nil {

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -108,7 +108,7 @@ func TestNoWillSubscribePublishClose(t *testing.T) {
 	    payload = "Hello will just publish world."
 `
 	expectedWill := false
-	ok := genericWillTestDriver(t, configStr, "testnowillafterclose/will", []byte(""), expectedWill)
+	ok := genericWillTestDriver(t, configStr, "/testnowillafterclose/will", []byte(""), expectedWill)
 	assert.True(ok, "Failed to receive Will message")
 }
 

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -293,6 +293,8 @@ func setupWillSubscriber(gw *gateway.Gateway, broker *broker.Broker) (chan MQTT.
 	opts.SetDefaultPublishHandler(func(client *MQTT.Client, msg MQTT.Message) {
 		messageOutputChannel <- msg
 	})
+	willQoS := 0
+        willTopic := broker.WillTopic
 
 	client := MQTT.NewClient(opts)
 	if client == nil {
@@ -302,9 +304,7 @@ func setupWillSubscriber(gw *gateway.Gateway, broker *broker.Broker) (chan MQTT.
 		return nil, config.Error(fmt.Sprintf("NewClient Start failed %q", token.Error()))
 	}
 
-	qos := 0
-	willTopic := fmt.Sprintf("%s/%s/will", broker.TopicPrefix, gw.Name)
-	client.Subscribe(willTopic, byte(qos), func(client *MQTT.Client, msg MQTT.Message) {
+	client.Subscribe(willTopic, byte(willQoS), func(client *MQTT.Client, msg MQTT.Message) {
 		messageOutputChannel <- msg
 	})
 

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -256,8 +256,6 @@ func genericWillTestDriver(t *testing.T, configStr string, expectedTopic string,
 	if err != nil {
 		t.Error("file path not found")
 	}
-	fmt.Println(fujiPath)
-	fmt.Println(tmpTomlName)
 	cmd := exec.Command(fujiPath, "-c", tmpTomlName)
 	err = cmd.Start()
 	if err != nil {

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -294,7 +294,7 @@ func setupWillSubscriber(gw *gateway.Gateway, broker *broker.Broker) (chan MQTT.
 		messageOutputChannel <- msg
 	})
 	willQoS := 0
-        willTopic := broker.WillTopic
+	willTopic := broker.WillTopic
 
 	client := MQTT.NewClient(opts)
 	if client == nil {

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -82,7 +82,7 @@ func TestWillWithPrefixSubscribePublishClose(t *testing.T) {
 	    payload = "Hello will with prefix."
 `
 	expectedWill := true
-	ok := genericWillTestDriver(t, configStr, "prefix/testprefixwill/will", []byte("Hello will with prefix."), expectedWill)
+	ok := genericWillTestDriver(t, configStr, "prefix/testprefixwill/will", []byte("no letter is good letter."), expectedWill)
 	assert.True(ok, "Failed to receive Will with prefix message")
 }
 


### PR DESCRIPTION
## configuration parameter added

- broker
    - client_cert : path of the certificate of client (signed by the CA which broker relies on)
    - client_key : path of the private key to generate client certificate

## testcase added

- TestTLSClientCertConnectLocalPub : just publish message via TLS connection
- TestTLSClientCertConnectLocalPubSub : subscribe via TLS connection to receive published message

## will test case driver fixed. 

added testcases revealed hidden bug of the code.
