### PR TITLE
enhancement: status.ip_address report capability 

### DIFF
--- a/device/status_test.go
+++ b/device/status_test.go
@@ -90,6 +90,7 @@ func TestIpAddressGet(t *testing.T) {
 	i := IpAddressStatus{
 		Interfaces: []string{"all"},
 	}
-	msgs := i.Get()
 	assert.NotNil(i)
+	msgs := i.Get()
+	assert.True(len(msgs) > 0)
 }

--- a/device/status_test.go
+++ b/device/status_test.go
@@ -47,6 +47,8 @@ func TestStatus(t *testing.T) {
   cpu_times = "user, system, idle, nice, iowait, irq, softirq, guest"
 [[status."memory"]]
   virtual_memory = "total, available, percent, used, free"
+[[status."ip_address"]]
+  interface = "eth0, lo0"
 [status]
   broker = "sango"
   interval = 10
@@ -63,7 +65,7 @@ func TestStatus(t *testing.T) {
 
 	assert.Equal(8, len(st.CPU.CpuTimes))
 	assert.Equal(5, len(st.Memory.VirtualMemory))
-
+	assert.Equal(2, len(st.IpAddress.Interfaces))
 }
 
 func TestCPUGet(t *testing.T) {
@@ -84,11 +86,22 @@ func TestMemoryGet(t *testing.T) {
 	assert.Equal(4, len(msgs))
 }
 
-func TestIpAddressGet(t *testing.T) {
+func TestIpAddressAllGet(t *testing.T) {
 	assert := assert.New(t)
 
 	i := IpAddressStatus{
 		Interfaces: []string{"all"},
+	}
+	assert.NotNil(i)
+	msgs := i.Get()
+	assert.True(len(msgs) > 0)
+}
+
+func TestIpAddressLoGet(t *testing.T) {
+	assert := assert.New(t)
+
+	i := IpAddressStatus{
+		Interfaces: []string{"lo0","en0"},
 	}
 	assert.NotNil(i)
 	msgs := i.Get()

--- a/device/status_test.go
+++ b/device/status_test.go
@@ -83,3 +83,13 @@ func TestMemoryGet(t *testing.T) {
 	msgs := c.Get()
 	assert.Equal(4, len(msgs))
 }
+
+func TestIpAddressGet(t *testing.T) {
+	assert := assert.New(t)
+
+	i := IpAddressStatus{
+		Interfaces: []string{"all"},
+	}
+	msgs := i.Get()
+	assert.NotNil(i)
+}


### PR DESCRIPTION
## configuration

to get IP addresses for all interfaces.

```
[[status."ip_address"]]
  interface = "all"
```

to get IP addresses of specific interfaces

```
[[status."ip_address"]]
  interface = "eth0, lo0"
```

## published message and its topic

### for `all` case, JSON object format message is published
topic

```
$SYS/gateway/GatewayName/ip_address/interface/all
```
message

```
[{"Name":"lo0","Addr":["::1/128","127.0.0.1/8","fe80::1/64"]},{"Name":"gif0","Addr":[]},{"Name":"stf0","Addr":[]},
{"Name":"en0","Addr":["fe80::ba8d:12ff:fe0d:7d06/64","192.168.1.147/20"]},{"Name":"en1","Addr":[]},{"Name":"p2p0","Addr":[]},{"Name":"bridge0","Addr":[]}]
```

### for `eth0, lo0` case, JSON list format messages are published

topic for `eth0`

```
$SYS/gateway/GatewayName/ip_address/interface/eth0
```
message for `eth0`

```
["fe80::ba8d:12ff:fe0d:7d06/64","192.168.1.147/20"]
```

topic for `lo0`

```
$SYS/gateway/GatewayName/ip_address/interface/lo0
```
message for `lo0`

```
["::1/128","127.0.0.1/8","fe80::1/64"]
```