### PR TITLE
eclipse.paho has been moved to github from eclipse repo.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -3,11 +3,6 @@
 	"GoVersion": "go1.5.3",
 	"Deps": [
 		{
-			"ImportPath": "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git",
-			"Comment": "v0.9.1-20-g617c801",
-			"Rev": "617c801af238c3af2d9e72c5d4a0f02edad03ce5"
-		},
-		{
 			"ImportPath": "github.com/BurntSushi/toml",
 			"Comment": "v0.1.0-23-g5c4df71",
 			"Rev": "5c4df71dfe9ac89ef6287afc05e4c1b16ae65a1e"
@@ -16,6 +11,11 @@
 			"ImportPath": "github.com/Sirupsen/logrus",
 			"Comment": "v0.9.0",
 			"Rev": "be52937128b38f1d99787bb476c789e2af1147f1"
+		},
+		{
+			"ImportPath": "github.com/eclipse/paho.mqtt.golang",
+			"Comment": "v0.9.1-21-g1833293",
+			"Rev": "183329365eb3c151b3f8403f90c89cf4e21ed739"
 		},
 		{
 			"ImportPath": "github.com/go-ole/go-ole",

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -24,8 +24,8 @@ import (
 	"strconv"
 	"strings"
 
-	MQTT "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
 	log "github.com/Sirupsen/logrus"
+	MQTT "github.com/eclipse/paho.mqtt.golang"
 	validator "gopkg.in/validator.v2"
 
 	"github.com/shiguredo/fuji/config"

--- a/tests/connect_test.go
+++ b/tests/connect_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	MQTT "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
+	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shiguredo/fuji"

--- a/tests/retain_test.go
+++ b/tests/retain_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	MQTT "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
+	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shiguredo/fuji"

--- a/tests/tls_clientcert_test.go
+++ b/tests/tls_clientcert_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	MQTT "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
+	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shiguredo/fuji"

--- a/tests/tls_connect_test.go
+++ b/tests/tls_connect_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	MQTT "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
+	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shiguredo/fuji"

--- a/tests/will_test.go
+++ b/tests/will_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	MQTT "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
+	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shiguredo/fuji"


### PR DESCRIPTION
Since eclipse paho repository has been moved to github, this PR changes import path to github.
Also, this changes `Godep.json`. 