### PR TITLE
fix serial subscribe topic mismatch

### DIFF
--- a/broker/subscribe.go
+++ b/broker/subscribe.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
+
+	"github.com/shiguredo/fuji/message"
 )
 
 type Subscribed struct {
@@ -64,12 +66,12 @@ func (s Subscribed) Delete(topic string) error {
 	delete(s.list, topic)
 	return nil
 }
-func (b *Broker) AddSubscribed(deviceName string, deviceType string, qos byte) error {
-	t := strings.Join([]string{b.TopicPrefix, b.GatewayName, deviceName, deviceType, "subscribe"}, "/")
+func (b *Broker) AddSubscribed(deviceTopic message.TopicString, qos byte) error {
+	t := strings.Join([]string{b.TopicPrefix, b.GatewayName, deviceTopic.String()}, "/")
 	log.Infof("subscribe: %#v", t)
 	return b.Subscribed.Add(t, qos)
 }
-func (b *Broker) DeleteSubscribed(deviceName string, qos byte) error {
-	t := strings.Join([]string{b.TopicPrefix, b.GatewayName, deviceName}, "/")
+func (b *Broker) DeleteSubscribed(deviceTopic message.TopicString, qos byte) error {
+	t := strings.Join([]string{b.TopicPrefix, b.GatewayName, deviceTopic.String()}, "/")
 	return b.Subscribed.Delete(t)
 }

--- a/broker/subscribe.go
+++ b/broker/subscribe.go
@@ -72,6 +72,6 @@ func (b *Broker) AddSubscribed(deviceTopic message.TopicString, qos byte) error 
 	return b.Subscribed.Add(t, qos)
 }
 func (b *Broker) DeleteSubscribed(deviceTopic message.TopicString, qos byte) error {
-	t := strings.Join([]string{b.TopicPrefix, b.GatewayName, deviceTopic.String()}, "/")
+	t := strings.Join([]string{b.TopicPrefix, b.GatewayName, deviceTopic.Str}, "/")
 	return b.Subscribed.Delete(t)
 }

--- a/broker/subscribe.go
+++ b/broker/subscribe.go
@@ -67,7 +67,7 @@ func (s Subscribed) Delete(topic string) error {
 	return nil
 }
 func (b *Broker) AddSubscribed(deviceTopic message.TopicString, qos byte) error {
-	t := strings.Join([]string{b.TopicPrefix, b.GatewayName, deviceTopic.String()}, "/")
+	t := strings.Join([]string{b.TopicPrefix, b.GatewayName, deviceTopic.Str}, "/")
 	log.Infof("subscribe: %#v", t)
 	return b.Subscribed.Add(t, qos)
 }

--- a/broker/subscribe.go
+++ b/broker/subscribe.go
@@ -64,8 +64,8 @@ func (s Subscribed) Delete(topic string) error {
 	delete(s.list, topic)
 	return nil
 }
-func (b *Broker) AddSubscribed(deviceName string, qos byte) error {
-	t := strings.Join([]string{b.TopicPrefix, b.GatewayName, deviceName, "subscribe"}, "/")
+func (b *Broker) AddSubscribed(deviceName string, deviceType string, qos byte) error {
+	t := strings.Join([]string{b.TopicPrefix, b.GatewayName, deviceName, deviceType, "subscribe"}, "/")
 	log.Infof("subscribe: %#v", t)
 	return b.Subscribed.Add(t, qos)
 }

--- a/device/dummy.go
+++ b/device/dummy.go
@@ -143,7 +143,7 @@ func (device DummyDevice) MainLoop(channel chan message.Message) error {
 			}
 			channel <- msg
 		case msg, _ := <-device.DeviceChan.Chan:
-			if !strings.HasSuffix(msg.Topic, device.SubscribeTopic.String()) {
+			if !strings.HasSuffix(msg.Topic, device.SubscribeTopic.Str) {
 				continue
 			}
 

--- a/device/dummy.go
+++ b/device/dummy.go
@@ -141,7 +141,7 @@ func (device DummyDevice) MainLoop(channel chan message.Message) error {
 			}
 			channel <- msg
 		case msg, _ := <-device.DeviceChan.Chan:
-			if !strings.HasSuffix(msg.Topic, device.SubscribeTopic.Str) {
+			if device.SubscribeTopic.Str == "" || !strings.HasSuffix(msg.Topic, device.SubscribeTopic.Str) {
 				continue
 			}
 

--- a/device/dummy.go
+++ b/device/dummy.go
@@ -164,7 +164,7 @@ func (device DummyDevice) AddSubscribe() error {
 		return nil
 	}
 	for _, b := range device.Broker {
-		b.AddSubscribed(device.Name, device.QoS)
+		b.AddSubscribed(device.Name, device.Type, device.QoS)
 	}
 	return nil
 }

--- a/device/dummy.go
+++ b/device/dummy.go
@@ -143,6 +143,9 @@ func (device DummyDevice) MainLoop(channel chan message.Message) error {
 			}
 			channel <- msg
 		case msg, _ := <-device.DeviceChan.Chan:
+			if !device.Subscribe {
+				continue
+			}
 			if !strings.HasSuffix(msg.Topic, device.SubscribeTopic.Str) {
 				continue
 			}

--- a/device/serial.go
+++ b/device/serial.go
@@ -238,7 +238,7 @@ func (device SerialDevice) Start(channel chan message.Message) error {
 				channel <- msg
 			case msg, _ := <-device.DeviceChan.Chan:
 				log.Infof("msg topic:, %v / %v", msg.Topic, device.Name)
-				if !strings.HasSuffix(msg.Topic, device.Name) {
+				if !strings.HasSuffix(msg.Topic, strings.Join([]string{device.Name, device.Type, "subscribe"}, "/")) {
 					continue
 				}
 				log.Infof("msg reached to device, %v", msg)

--- a/device/serial.go
+++ b/device/serial.go
@@ -242,7 +242,7 @@ func (device SerialDevice) Start(channel chan message.Message) error {
 				channel <- msg
 			case msg, _ := <-device.DeviceChan.Chan:
 				log.Infof("msg topic:, %v / %v", msg.Topic, device.Name)
-				if !strings.HasSuffix(msg.Topic, device.SubscribeTopic.String()) {
+				if !strings.HasSuffix(msg.Topic, device.SubscribeTopic.Str) {
 					continue
 				}
 				log.Infof("msg reached to device, %v", msg)

--- a/device/serial.go
+++ b/device/serial.go
@@ -42,9 +42,8 @@ type SerialDevice struct {
 	Type           string `validate:"max=256"`
 	Interval       int    `validate:"min=0"`
 	Retain         bool
-	Subscribe      bool
-	SubscribeTopic message.TopicString
-	DeviceChan     DeviceChannel // GW -> device
+	SubscribeTopic message.TopicString // initialized as ""
+	DeviceChan     DeviceChannel       // GW -> device
 }
 
 func (device SerialDevice) String() string {
@@ -113,7 +112,6 @@ func NewSerialDevice(section config.ConfigSection, brokers []*broker.Broker, dev
 
 	sub, ok := values["subscribe"]
 	if ok && sub == "true" {
-		ret.Subscribe = true
 		ret.SubscribeTopic = message.TopicString{
 			Str: strings.Join([]string{ret.Name, ret.Type, "subscribe"}, "/"),
 		}
@@ -242,9 +240,6 @@ func (device SerialDevice) Start(channel chan message.Message) error {
 				channel <- msg
 			case msg, _ := <-device.DeviceChan.Chan:
 				log.Infof("msg topic:, %v / %v", msg.Topic, device.Name)
-				if !device.Subscribe {
-					continue
-				}
 				if !strings.HasSuffix(msg.Topic, device.SubscribeTopic.Str) {
 					continue
 				}
@@ -272,7 +267,7 @@ func (device SerialDevice) DeviceType() string {
 }
 
 func (device SerialDevice) AddSubscribe() error {
-	if !device.Subscribe {
+	if device.SubscribeTopic.Str == "" {
 		return nil
 	}
 	for _, b := range device.Broker {

--- a/device/serial.go
+++ b/device/serial.go
@@ -240,7 +240,7 @@ func (device SerialDevice) Start(channel chan message.Message) error {
 				channel <- msg
 			case msg, _ := <-device.DeviceChan.Chan:
 				log.Infof("msg topic:, %v / %v", msg.Topic, device.Name)
-				if !strings.HasSuffix(msg.Topic, device.SubscribeTopic.Str) {
+				if device.SubscribeTopic.Str == "" || !strings.HasSuffix(msg.Topic, device.SubscribeTopic.Str) {
 					continue
 				}
 				log.Infof("msg reached to device, %v", msg)

--- a/device/serial.go
+++ b/device/serial.go
@@ -242,6 +242,9 @@ func (device SerialDevice) Start(channel chan message.Message) error {
 				channel <- msg
 			case msg, _ := <-device.DeviceChan.Chan:
 				log.Infof("msg topic:, %v / %v", msg.Topic, device.Name)
+				if !device.Subscribe {
+					continue
+				}
 				if !strings.HasSuffix(msg.Topic, device.SubscribeTopic.Str) {
 					continue
 				}

--- a/device/serial.go
+++ b/device/serial.go
@@ -269,7 +269,7 @@ func (device SerialDevice) AddSubscribe() error {
 		return nil
 	}
 	for _, b := range device.Broker {
-		b.AddSubscribed(device.Name, device.QoS)
+		b.AddSubscribed(device.Name, device.Type, device.QoS)
 	}
 	return nil
 }

--- a/message/topicstring.go
+++ b/message/topicstring.go
@@ -34,7 +34,7 @@ type TopicString struct {
 	Str string `validate:"max=32767,validtopic"`
 }
 
-func (topic TopicString) Sring() string {
+func (topic TopicString) String() string {
 	return fmt.Sprintf("Topic: %s", topic.Str)
 }
 


### PR DESCRIPTION
The serial device subscribe topic:

USED TO BE: <topicPrefix>/<gatewayName>/<deviceName>/subscribe
SHOULD BE: <topicPrefix>/<gatewayName>/<deviceName>/<type>/subscribe

Because of this mismatch, we could not output message data of subscribed topic to serial port.

Subscribe topic registration and validation codes are fixed.