### PR TITLE
fix duplication of client ID

### DIFF
--- a/tests/tls_connect_test.go
+++ b/tests/tls_connect_test.go
@@ -32,7 +32,7 @@ import (
 var configStr = `
 [gateway]
 
-    name = "hamlocalconnect"
+    name = "tlshamlocalconnect"
 
 [[broker."mosquitto/1"]]
 


### PR DESCRIPTION
In tests/tls_connect_test.go, MQTT client ID is the same as tests/connect_test.go.
It caused unexpected connection close.
So the client ID is changed.