### PR TITLE
update Go version to 1.6.2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ machine:
     PATH: "/home/ubuntu/go/bin:${PATH}:${GOPATH}/bin"
     GO15VENDOREXPERIMENT: 1
     GOROOT: "/home/ubuntu/go"
-    GOVERSION: "1.6"
+    GOVERSION: "1.6.2"
   services:
     - docker
 


### PR DESCRIPTION
All test passed with Go version 1.6.2 binary.
And, CircleCI build process and its artifacts confirmed its version.