### PR TITLE
fix config toml sample.

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -122,7 +122,7 @@
 #    type = "serial"
 #
 # # serial port path
-#    serial = /dev/tty.usbserial
+#    serial = "/dev/tty.usbserial"
 #
 # # 
 #    baud = 57600 
@@ -222,7 +222,7 @@
 #    qos = 0
 #    type = "serial"
 #    
-#    serial = /dev/tty.usbserial
+#    serial = "/dev/tty.usbserial"
 #    baud = 57600 
 
 
@@ -247,7 +247,7 @@
 #    type = "serial"
 #    subscribe = true
 #    
-#    serial = /dev/tty.usbserial
+#    serial = "/dev/tty.usbserial"
 #    baud = 57600 
 
 


### PR DESCRIPTION
String should be enclosed by quotation in TOML, but the example is not. This PR fixes it.

```
serial = "/dev/tty.usbserial"
```